### PR TITLE
fix: corrigir import do sequelize em dashboarService.js

### DIFF
--- a/services/dashboarService.js
+++ b/services/dashboarService.js
@@ -1,7 +1,7 @@
 const { XLOCK } = require('sequelize/lib/table-hints')
 const Client = require('../models/Client.js')
 const Sessions = require('../models/Session.js')
-const {Op, fn, literal} = require('../sequelize')
+const {Op, fn, literal} = require('sequelize')
 const { Where } = require('sequelize/lib/utils')
 
 async function totalSessionsOfDay(user_id, day, month, year) {


### PR DESCRIPTION
- Alterar require('../sequelize') para require('sequelize')
- Resolve MODULE_NOT_FOUND error ao iniciar servidor