### PR TITLE
criacao da rota getTatuadores e ajuste para integracao com login

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,7 +20,15 @@ const generatedImages = require('./routes/aiGalleryRoutes.js')
 const allowedOrigins =
   process.env.NODE_ENV === "production"
     ? [process.env.FRONTEND_URL]
-    : ["http://localhost:5173", "http://127.0.0.1:5173"];
+  : [
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+      "http://localhost:8081",
+      "http://127.0.0.1:8081",
+      "http://10.0.2.2:8081", // Android emulador
+      "exp://127.0.0.1:8081", // Expo
+      "exp://localhost:8081"
+    ];
 
 app.use(
   cors({

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -190,4 +190,27 @@ async function alterarSenha(req, res) {
   }
 }
 
-module.exports = { register, login, recoverPassword, alterarSenha };
+async function getTatuadores(req, res) {
+  try {
+    const { q, style } = req.query;
+    let where = { role: { [require('sequelize').Sequelize.Op.ne]: 'cliente' } };
+
+    if (q) {
+      where[require('sequelize').Sequelize.Op.or] = [
+        { nome: { [require('sequelize').Sequelize.Op.iLike]: `%${q}%` } },
+        { sobrenome: { [require('sequelize').Sequelize.Op.iLike]: `%${q}%` } },
+        { endereco: { [require('sequelize').Sequelize.Op.iLike]: `%${q}%` } },
+      ];
+    }
+
+    const include = style ? [{ model: Style, where: { nome: style }, required: true }] : [Style];
+
+    const tatuadores = await User.findAll({ where, include });
+    return res.status(200).json(tatuadores);
+  } catch (error) {
+    console.error(error);
+    return res.status(400).json({ message: error.message });
+  }
+}
+
+module.exports = { register, login, recoverPassword, alterarSenha, getTatuadores };

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -6,6 +6,7 @@ router.post('/register', userController.register);
 router.post('/login', userController.login);
 router.post('/recuperar-senha', userController.recoverPassword);
 router.post('/alterar-senha', userController.alterarSenha);
+router.get('/tatuadores', userController.getTatuadores);
 
 
 module.exports = router;


### PR DESCRIPTION
Este PR implementa a criação da rota getTatuadores no back-end e realiza ajustes necessários para integração com o fluxo de autenticação (login), além de viabilizar o consumo dessa rota pela BuscaScreen no front-end.

A rota foi desenvolvida com o objetivo de fornecer os dados necessários para a tela de busca, onde são exibidas as informações dos tatuadores cadastrados na plataforma.